### PR TITLE
Return valid XML for GetSnapshotUri

### DIFF
--- a/services/media_service.ts
+++ b/services/media_service.ts
@@ -295,14 +295,14 @@ class MediaService extends SoapService {
     };
 
     port.GetSnapshotUri = (args) => {
-      var GetSnapshotUriResponse = {};
-      //  MediaUri : {
-      //    Uri : "http://" + config.IpAddress + ":" + config.ServicePort + "/web/snapshot.jpg",
-      //    Timeout : "PT30S",
-      //    InvalidAfterConnect : false,
-      //    InvalidAfterReboot : false
-      //  }
-      //};
+      var GetSnapshotUriResponse = {
+        MediaUri : {
+          Uri : "http://" + this.config.IpAddress + ":" + this.config.ServicePort + "/web/snapshot.jpg",
+          InvalidAfterConnect : false,
+          InvalidAfterReboot : false,
+          Timeout : "PT30S"
+        }
+      };
       return GetSnapshotUriResponse;
     };
 


### PR DESCRIPTION
The XML returned for GetSnapshotUri was not valid (and would crash some CCTV viewing software). Change the code to return a valid XML message.
I noted that the CCTV viewing software will then fetch /web/snapshot.jpg and the HTTP server is looking for an image in /dev/shm so other fixes are needed. But this change stops my CCTV viewing software from crashing.