### PR TITLE
Add multicast support

### DIFF
--- a/lib/camera.ts
+++ b/lib/camera.ts
@@ -174,8 +174,12 @@ class Camera {
     }
     utils.log.info("Starting Live555 rtsp server");
 
-    if (this.config.RTSPServer == 1) this.rtspServer = utils.spawn("./bin/rtspServer", ["/dev/video0", "2088960", this.config.RTSPPort.toString(), "0", this.config.RTSPName.toString()]);
-    if (this.config.RTSPServer == 2) this.rtspServer = utils.spawn("h264_v4l2_rtspserver", ["-P",this.config.RTSPPort.toString(), "-u" , this.config.RTSPName.toString(),"-W",this.settings.resolution.Width.toString(),"-H",this.settings.resolution.Height.toString(),"/dev/video0"]);
+    if (this.config.MulticastEnabled) {
+        this.rtspServer = utils.spawn("h264_v4l2_rtspserver", ["-P", this.config.RTSPPort.toString(), "-u" , this.config.RTSPName.toString(), "-m", this.config.RTSPMulticastName, "-M", this.config.MulticastAddress.toString() + ":" + this.config.MulticastPort.toString(), "-W",this.settings.resolution.Width.toString(), "-H", this.settings.resolution.Height.toString(), "/dev/video0"]);
+    } else {
+        if (this.config.RTSPServer == 1) this.rtspServer = utils.spawn("./bin/rtspServer", ["/dev/video0", "2088960", this.config.RTSPPort.toString(), "0", this.config.RTSPName.toString()]);
+        if (this.config.RTSPServer == 2) this.rtspServer = utils.spawn("h264_v4l2_rtspserver", ["-P",this.config.RTSPPort.toString(), "-u" , this.config.RTSPName.toString(),"-W",this.settings.resolution.Width.toString(),"-H",this.settings.resolution.Height.toString(),"/dev/video0"]);
+    }
 
     this.rtspServer.stdout.on('data', data => utils.log.debug("rtspServer: %s", data));
     this.rtspServer.stderr.on('data', data => utils.log.error("rtspServer: %s", data));

--- a/lib/camera.ts
+++ b/lib/camera.ts
@@ -64,7 +64,7 @@ class Camera {
       this.unloadDriver();
     });
 
-    fs.chmodSync("./bin/rtspServer", "0755");
+    if (this.config.RTSPServer == 1 )fs.chmodSync("./bin/rtspServer", "0755");
   }
   setupWebserver() {
     utils.log.info("Starting camera settings webserver on http://%s:%s/", utils.getIpAddress(), this.config.ServicePort);
@@ -174,7 +174,8 @@ class Camera {
     }
     utils.log.info("Starting Live555 rtsp server");
 
-    this.rtspServer = utils.spawn("./bin/rtspServer", ["/dev/video0", "2088960", this.config.RTSPPort.toString(), "0", this.config.RTSPName.toString()]);
+    if (this.config.RTSPServer == 1) this.rtspServer = utils.spawn("./bin/rtspServer", ["/dev/video0", "2088960", this.config.RTSPPort.toString(), "0", this.config.RTSPName.toString()]);
+    if (this.config.RTSPServer == 2) this.rtspServer = utils.spawn("h264_v4l2_rtspserver", ["-P",this.config.RTSPPort.toString(), "-u" , this.config.RTSPName.toString(),"-W",this.settings.resolution.Width.toString(),"-H",this.settings.resolution.Height.toString(),"/dev/video0"]);
 
     this.rtspServer.stdout.on('data', data => utils.log.debug("rtspServer: %s", data));
     this.rtspServer.stderr.on('data', data => utils.log.error("rtspServer: %s", data));

--- a/rpos.d.ts
+++ b/rpos.d.ts
@@ -5,6 +5,7 @@ interface rposConfig {
   ServicePort: number;
   RTSPPort: number;
   RTSPName: string;
+  RTSPServer: number;
   DeviceInformation: DeviceInformation;
   logLevel: number;
   logSoapCalls: Boolean;

--- a/rpos.d.ts
+++ b/rpos.d.ts
@@ -6,6 +6,10 @@ interface rposConfig {
   RTSPPort: number;
   RTSPName: string;
   RTSPServer: number;
+  MulticastEnabled: boolean;
+  RTSPMulticastName : string;
+  MulticastAddress: string;
+  MulticastPort: number;
   DeviceInformation: DeviceInformation;
   logLevel: number;
   logSoapCalls: Boolean;

--- a/rposConfig.json
+++ b/rposConfig.json
@@ -4,7 +4,11 @@
   "ServicePort" : 8081,
   "RTSPPort" : 8554,
   "RTSPName" : "h264",
-  "RTSPServer" : 1, "RtspServerComment" : "## Select RTSP Server > 1:RPOS RTSP Server 2:V4L2 RTSP Server by mpromonet",
+  "MulticastEnabled"  : false,
+  "RTSPMulticastName" : "h264m",
+  "MulticastAddress"  : "224.0.0.1",
+  "MulticastPort"     : "10001",
+  "RTSPServer" : 1, "RtspServerComment" : "## Select RTSP Server > 1:RPOS RTSP Server 2:V4L2 RTSP Server by mpromonet (auto selected if MulticastEnabled=true)",
   "DeviceInformation" : {
     "Manufacturer" : "Raspberry Pi",
     "Model" : "2 B",

--- a/rposConfig.json
+++ b/rposConfig.json
@@ -4,6 +4,7 @@
   "ServicePort" : 8081,
   "RTSPPort" : 8554,
   "RTSPName" : "h264",
+  "RTSPServer" : 1, "RtspServerComment" : "## Select RTSP Server > 1:RPOS RTSP Server 2:V4L2 RTSP Server by mpromonet",
   "DeviceInformation" : {
     "Manufacturer" : "Raspberry Pi",
     "Model" : "2 B",

--- a/rposConfig.release.json
+++ b/rposConfig.release.json
@@ -4,7 +4,11 @@
   "ServicePort" : 8081,
   "RTSPPort" : 8554,
   "RTSPName" : "h264",
-  "RTSPServer" : 1, "RtspServerComment" : "## Select RTSP Server > 1:RPOS RTSP Server 2:V4L2 RTSP Server by mpromonet",
+  "MulticastEnabled"  : false,
+  "RTSPMulticastName" : "h264m",
+  "MulticastAddress"  : "224.0.0.1",
+  "MulticastPort"     : "10001",
+  "RTSPServer" : 1, "RtspServerComment" : "## Select RTSP Server > 1:RPOS RTSP Server 2:V4L2 RTSP Server by mpromonet (auto selected if MulticastEnabled=true)",
   "DeviceInformation" : {
     "Manufacturer" : "Raspberry Pi",
     "Model" : "2 B",

--- a/rposConfig.release.json
+++ b/rposConfig.release.json
@@ -4,6 +4,7 @@
   "ServicePort" : 8081,
   "RTSPPort" : 8554,
   "RTSPName" : "h264",
+  "RTSPServer" : 1, "RtspServerComment" : "## Select RTSP Server > 1:RPOS RTSP Server 2:V4L2 RTSP Server by mpromonet",
   "DeviceInformation" : {
     "Manufacturer" : "Raspberry Pi",
     "Model" : "2 B",

--- a/services/device_service.ts
+++ b/services/device_service.ts
@@ -153,7 +153,7 @@ class DeviceService extends SoapService {
         GetCapabilitiesResponse.Capabilities["Media"] = {
           XAddr: `http://${utils.getIpAddress() }:${this.config.ServicePort}/onvif/media_service`,
           StreamingCapabilities: {
-            RTPMulticast: false,
+            RTPMulticast: this.config.MulticastEnabled,
             RTP_TCP: true,
             RTP_RTSP_TCP: true,
             Extension: {}

--- a/services/media_service.ts
+++ b/services/media_service.ts
@@ -193,7 +193,7 @@ class MediaService extends SoapService {
           },
           StreamingCapabilities: {
             attributes: {
-              RTPMulticast: false,
+              RTPMulticast: this.config.MulticastEnabled,
               RTP_TCP: true,
               RTP_RTSP_TCP: true,
               NonAggregateControl: false,
@@ -204,7 +204,7 @@ class MediaService extends SoapService {
       };
       return GetServiceCapabilitiesResponse;
     };
-  
+
     //var GetStreamUri = { 
     //StreamSetup : { 
     //Stream : { xs:string}
@@ -213,9 +213,14 @@ class MediaService extends SoapService {
     //
     //};
     port.GetStreamUri = (args /*, cb, headers*/) => {
+
+     let stream = args.StreamSetup.Stream;
+
       var GetStreamUriResponse = {
         MediaUri: {
-          Uri: `rtsp://${utils.getIpAddress() }:${this.config.RTSPPort}/${this.config.RTSPName}`,
+          streamUri: (args.StreamSetup.Stream == "RTP-Multicast" && this.config.MulticastEnabled ? 
+            `rtsp://${utils.getIpAddress() }:${this.config.RTSPPort}/${this.config.RTSPMulticastName}` :
+            `rtsp://${utils.getIpAddress() }:${this.config.RTSPPort}/${this.config.RTSPName}`),
           InvalidAfterConnect: false,
           InvalidAfterReboot: false,
           Timeout: "PT30S"


### PR DESCRIPTION
This commit adds initial multicast support to RPOS buy using the mpromonet RTSP Server ([https://github.com/mpromonet/h264_v4l2_rtspserver](https://github.com/mpromonet/h264_v4l2_rtspserver)).

When Multicast is enabled in rposConfig.json the RPOS server does the following
a) Multicast support is advertised in GetCapabilities.
b) When asking for a RTP-Multicast stream in GetStreamUri, the RTSP address to start the multicast stream is returned. Otherwise the normal Unicast address is returned.

The change also allows you to select a different RTSP server. This could be extended in the future to use other RTSP servers for example vlc / cvlc