### PR TITLE
Quick fix of SoapService auth

### DIFF
--- a/lib/SoapService.ts
+++ b/lib/SoapService.ts
@@ -70,6 +70,10 @@ class SoapService {
     };
     this.serviceInstance = soap.listen(this.webserver, this.serviceOptions);
 
+    if (this.config.Username) {
+      this.serviceInstance.authenticate = () => true;
+    }
+
     this.serviceInstance.on('headers', (headers, methodName) => {
       // Use the '=>' notation so 'this' refers to the class we are in
       // ONVIF allows GetSystemDateAndTime to be sent with no authenticaton header


### PR DESCRIPTION
I found a way to fix auth issues when no headers are sent (https://github.com/BreeeZe/rpos/issues/67). I don't think it's the cleanest way to fix the issue but it seems to work.